### PR TITLE
Add try_acquire methods to sync and sync_threadsafe buckets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ required-features = ["sync-threadsafe"]
 name = "test_tokens"
 required-features = ["sync-threadsafe"]
 
+[[test]]
+name = "try_acquire"
+required-features = ["sync", "sync-threadsafe"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,26 @@ sync-threadsafe = []
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros"] }
 
+[[test]]
+name = "issue5"
+required-features = ["sync-threadsafe"]
+
+[[test]]
+name = "test_ao_issue"
+required-features = ["sync-threadsafe"]
+
+[[test]]
+name = "test_overflow"
+required-features = ["sync-threadsafe"]
+
+[[test]]
+name = "test_rate_limit_target"
+required-features = ["sync-threadsafe"]
+
+[[test]]
+name = "test_tokens"
+required-features = ["sync-threadsafe"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@
     unused,
     warnings
 )]
+// Document required features when the `docsrs` cfg set
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "tokio")]
 mod tokio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,78 @@
 
 #[cfg(feature = "tokio")]
 mod tokio;
+
 #[cfg(feature = "tokio")]
 pub use crate::tokio::*;
 #[cfg(feature = "sync")]
 pub mod sync;
 #[cfg(feature = "sync-threadsafe")]
 pub mod sync_threadsafe;
+
+use std::time::Instant;
+
+/// Error returned from the `try_acquire` functions when the operation can't be completed immediately.
+#[derive(Debug)]
+pub struct TryAcquireError {
+    kind: TryAcquireErrorKind,
+}
+
+#[derive(Debug)]
+enum TryAcquireErrorKind {
+    /// The lock can't be acquired without waiting.
+    Locked,
+    /// Not enough tokens are available.
+    InsufficientTokens(Instant),
+}
+
+impl std::error::Error for TryAcquireError {}
+
+impl std::fmt::Display for TryAcquireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            TryAcquireErrorKind::Locked => write!(f, "operation would block"),
+            TryAcquireErrorKind::InsufficientTokens(_i) => {
+                write!(f, "insufficient tokens available to fulfill the request")
+            }
+        }
+    }
+}
+
+impl TryAcquireError {
+    const fn new_locked() -> Self {
+        Self {
+            kind: TryAcquireErrorKind::Locked,
+        }
+    }
+
+    const fn new_insufficient_tokens(target_time: Instant) -> Self {
+        Self {
+            kind: TryAcquireErrorKind::InsufficientTokens(target_time),
+        }
+    }
+
+    /// Returns `true` if the call failed because the internal lock couldn't be acquired without waiting.
+    #[must_use]
+    pub const fn is_locked(&self) -> bool {
+        matches!(self.kind, TryAcquireErrorKind::Locked)
+    }
+
+    /// Returns `true` if the call failed because there were not enough tokens available without waiting.
+    #[must_use]
+    pub const fn is_insufficient_tokens(&self) -> bool {
+        matches!(self.kind, TryAcquireErrorKind::InsufficientTokens(_))
+    }
+
+    /// Return the time at which enough tokens would be available to return without waiting.
+    ///
+    /// Depending on the cause of this error, this value might be unknown.
+    ///
+    /// This only applies, if no other token is requested in the meantime.
+    #[must_use]
+    pub const fn target_time(&self) -> Option<Instant> {
+        match self.kind {
+            TryAcquireErrorKind::Locked => None,
+            TryAcquireErrorKind::InsufficientTokens(target_time) => Some(target_time),
+        }
+    }
+}

--- a/tests/test_next_refill.rs
+++ b/tests/test_next_refill.rs
@@ -11,18 +11,18 @@ async fn test_next_refill() {
         .build();
 
     let next_refill = rate_limiter.next_refill();
-    let until = next_refill.duration_since(Instant::now());
+    let until = next_refill.await.duration_since(Instant::now());
     assert!((until.as_secs_f64() - 2.).abs() < 0.1);
 
     sleep(Duration::from_secs(3)).await;
 
     let next_refill = rate_limiter.next_refill();
-    let until = next_refill.duration_since(Instant::now());
+    let until = next_refill.await.duration_since(Instant::now());
     assert!((until.as_secs_f64() - 1.).abs() < 0.1);
 
     rate_limiter.acquire(5).await;
 
     let next_refill = rate_limiter.next_refill();
-    let until = next_refill.duration_since(Instant::now());
+    let until = next_refill.await.duration_since(Instant::now());
     assert!((until.as_secs_f64() - 1.).abs() < 0.1);
 }

--- a/tests/try_acquire.rs
+++ b/tests/try_acquire.rs
@@ -1,0 +1,188 @@
+use leaky_bucket_lite::TryAcquireError;
+use std::{
+    future::ready,
+    time::{Duration, Instant},
+};
+
+#[tokio::test]
+async fn test_tokio() {
+    use leaky_bucket_lite::LeakyBucket;
+
+    let rate_limiter = LeakyBucket::builder()
+        .max(5)
+        .tokens(5)
+        .refill_amount(1)
+        .refill_interval(Duration::from_millis(100))
+        .build();
+
+    let begin = Instant::now();
+
+    assert!(matches!(rate_limiter.try_acquire(5), Ok(())));
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(1),
+        begin,
+        Duration::from_millis(100),
+    );
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(2),
+        begin,
+        Duration::from_millis(200),
+    );
+    assert!(matches!(rate_limiter.try_acquire(1), Ok(())));
+
+    rate_limiter.acquire(1).await;
+    assert_duration_equal(begin.elapsed(), Duration::from_millis(200));
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn({
+        let rate_limiter = rate_limiter.clone();
+        async move {
+            let fut = rate_limiter.acquire(1);
+            tokio::pin!(fut);
+            // poll the future once, to ensure the lock is acquired
+            tokio::select! {
+              biased;
+
+              _ = &mut fut => (),
+              _ = ready(()) => {
+                tx.send(()).unwrap();
+              }
+            };
+            // poll the future to completion, which releases the lock
+            fut.await;
+        }
+    });
+    // wait until the lock is acquired
+    rx.await.unwrap();
+    assert_is_locked(rate_limiter.try_acquire(1));
+
+    rate_limiter.acquire(1).await;
+    assert_duration_equal(begin.elapsed(), Duration::from_millis(400));
+
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(1),
+        begin,
+        Duration::from_millis(500),
+    );
+}
+
+#[test]
+fn test_sync_threadsafe() {
+    use leaky_bucket_lite::sync_threadsafe::LeakyBucket;
+
+    let rate_limiter = LeakyBucket::builder()
+        .max(5)
+        .tokens(5)
+        .refill_amount(1)
+        .refill_interval(Duration::from_millis(100))
+        .build();
+
+    let begin = Instant::now();
+
+    assert!(matches!(rate_limiter.try_acquire(5), Ok(())));
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(1),
+        begin,
+        Duration::from_millis(100),
+    );
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(2),
+        begin,
+        Duration::from_millis(200),
+    );
+    assert!(matches!(rate_limiter.try_acquire(1), Ok(())));
+
+    rate_limiter.acquire(1);
+    assert_duration_equal(begin.elapsed(), Duration::from_millis(200));
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    {
+        let rate_limiter = rate_limiter.clone();
+        std::thread::spawn(move || {
+            tx.send(()).unwrap();
+            rate_limiter.acquire(1);
+        });
+    };
+
+    // wait until the thread is running
+    rx.recv().unwrap();
+    // give the thread some time to acquire the lock
+    std::thread::sleep(Duration::from_millis(5));
+    assert_is_locked(rate_limiter.try_acquire(1));
+
+    rate_limiter.acquire(1);
+    assert_duration_equal(begin.elapsed(), Duration::from_millis(400));
+
+    assert_is_insufficient_tokens(
+        rate_limiter.try_acquire(1),
+        begin,
+        Duration::from_millis(500),
+    );
+}
+
+#[test]
+fn test_sync() {
+    use leaky_bucket_lite::sync_threadsafe::LeakyBucket;
+
+    let rate_limiter = LeakyBucket::builder()
+        .max(5)
+        .tokens(5)
+        .refill_amount(1)
+        .refill_interval(Duration::from_millis(100))
+        .build();
+
+    let begin = Instant::now();
+
+    let assert_is_insufficient_tokens = |r: Result<(), TryAcquireError>, d| match r {
+        Ok(()) => panic!("try_acquire should have failed"),
+        Err(e) => {
+            assert!(e.is_insufficient_tokens());
+            assert!(!e.is_locked());
+            assert_duration_equal(e.target_time().unwrap().duration_since(begin), d);
+        }
+    };
+
+    assert!(matches!(rate_limiter.try_acquire(5), Ok(())));
+    assert_is_insufficient_tokens(rate_limiter.try_acquire(1), Duration::from_millis(100));
+
+    std::thread::sleep(Duration::from_millis(100));
+
+    assert_is_insufficient_tokens(rate_limiter.try_acquire(2), Duration::from_millis(200));
+    assert!(matches!(rate_limiter.try_acquire(1), Ok(())));
+
+    rate_limiter.acquire(1);
+    assert_duration_equal(begin.elapsed(), Duration::from_millis(200));
+}
+
+fn assert_duration_equal(d1: Duration, d2: Duration) {
+    let diff = (d1.as_secs_f64() - d2.as_secs_f64()).abs();
+    assert!(diff < 0.02, "{:?} differs from {:?} by {}s", d1, d2, diff);
+}
+
+fn assert_is_insufficient_tokens(r: Result<(), TryAcquireError>, begin: Instant, d: Duration) {
+    match r {
+        Ok(()) => panic!("try_acquire should have failed"),
+        Err(e) => {
+            assert!(e.is_insufficient_tokens());
+            assert!(!e.is_locked());
+            assert_duration_equal(e.target_time().unwrap().duration_since(begin), d);
+        }
+    };
+}
+
+fn assert_is_locked(r: Result<(), TryAcquireError>) {
+    match r {
+        Ok(()) => panic!("try_acquire should have failed"),
+        Err(e) => {
+            assert!(e.is_locked());
+            assert!(!e.is_insufficient_tokens());
+            assert_eq!(None, e.target_time());
+        }
+    };
+}


### PR DESCRIPTION
These methods allow the user to perfom it's own actions in case not enough tokens are available.

This is particularly helpful when the user wants to drop work instead of waiting for the tokens to become ready.