### PR TITLE
Supporting refilling the number of tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["algorithms", "network-programming", "concurrency"]
 [dependencies]
 parking_lot = { version = "0.12", default-features = false, optional = true }
 tokio = { version = "1", default-features = false, features = ["time", "sync"], optional = true }
+flume = { version = "0.10", features = ["async"] }
 
 [features]
 default = ["tokio"]


### PR DESCRIPTION
This allows for use in a rate limiter in API's like Shopify GraphQL where the only an estimated usage is known ahead of time and an actual usage is provided by the response